### PR TITLE
Animated NFT Title

### DIFF
--- a/apps/dev-tool/pages/index.tsx
+++ b/apps/dev-tool/pages/index.tsx
@@ -64,9 +64,8 @@ const baseSparkleSet: Sparkle[] = [
 const Home: NextPage = () => {
   const [shape, setShape] = React.useState("halo0");
   const [rhythm, setRhythm] = React.useState("10");
-  const [background, setBackground] = React.useState<"linear" | "radial">(
-    "radial"
-  );
+  const [background, setBackground] =
+    React.useState<"linear" | "radial">("radial");
   const [bgColor, setBgColor] = React.useState<HSLColor>({
     hue: 50,
     saturation: 50,
@@ -80,9 +79,11 @@ const Home: NextPage = () => {
   const [stoneSettings, setStoneSettings] = React.useState(baseStoneSettings);
   const [xp, setXp] = React.useState(3221);
   const [level, setLevel] = React.useState("level3");
-  const [location, setLocation] = React.useState<
-    { latitude: number; longitude: number } | undefined
-  >(undefined);
+  const [title, setTitle] = React.useState("FLOURISHING MISTY WORLD");
+  const [location, setLocation] =
+    React.useState<{ latitude: number; longitude: number } | undefined>(
+      undefined
+    );
   let URLtimer: ReturnType<typeof setTimeout>;
 
   useEffect(() => {
@@ -102,6 +103,7 @@ const Home: NextPage = () => {
       setLevel(decodedSettings.level);
       setBgColor(decodedSettings.bgColor);
       setBgRealm(decodedSettings.bgRealm);
+      setTitle(decodedSettings.title);
     }
   }, []);
 
@@ -121,6 +123,7 @@ const Home: NextPage = () => {
         level,
         bgRealm,
         bgColor,
+        title,
       };
 
       const base64Settings = window.btoa(JSON.stringify(wandState));
@@ -140,6 +143,7 @@ const Home: NextPage = () => {
     level,
     bgRealm,
     bgColor,
+    title,
   ]);
 
   const addEmboss = () => {
@@ -291,6 +295,15 @@ const Home: NextPage = () => {
                 value={xp}
               />
             </CollapseContainer>
+            <CollapseContainer title="Portal Title">
+              <input
+                onChange={(e) => {
+                  setTitle(e.target.value);
+                }}
+                type="text"
+                value={title}
+              />
+            </CollapseContainer>
             <CollapseContainer wide title="Emboss Layers" collapse>
               <ul>
                 {embossLayers.map((layer, index) => (
@@ -321,7 +334,7 @@ const Home: NextPage = () => {
         </div>
         <div className={styles.wandImage}>
           <SvgTemplate
-            frame={{ title: "FLOURISHING MISTY WORLD", [level]: true }}
+            frame={{ title, [level]: true }}
             seed={123}
             planets={calculatePlanetPositions(
               location?.latitude || 0,

--- a/svg/partials/frame.hbs
+++ b/svg/partials/frame.hbs
@@ -447,5 +447,15 @@
 {{~/if~}}
 
 <path opacity="0.4" d="M 529.085 2844.789 L 454.584 2930.999 L 1545.417 2930.989 L 1470.942 2844.789 L 529.085 2844.789 Z" fill="#00000055" stroke="white" stroke-width="3.75"/>
+<clipPath id="tc">
+  <path d="M 529.085 2844.789 L 454.584 2930.999 L 1545.417 2930.989 L 1470.942 2844.789 L 529.085 2844.789 Z" fill="black"/>
+</clipPath>
+{{!-- <text text-anchor="middle" x="1000" y="2905" class="title">{{title}}</text> --}}
 
-<text text-anchor="middle" x="1000" y="2905" class="title">{{title}}</text>
+<path id="ng" d="M 480 2905 L 1520 2905" stroke="none"/>
+<text text-anchor="middle" class="title" clip-path="url(#tc)">
+<textPath href="#ng" startOffset="50%">
+<animate attributeName="startOffset" from="150%" to="-50%" begin="0s" dur="20s" repeatCount="indefinite"></animate>
+{{title}}
+</textPath>
+</text>

--- a/svg/partials/frame.hbs
+++ b/svg/partials/frame.hbs
@@ -455,7 +455,7 @@
 <path id="ng" d="M 480 2905 L 1520 2905" stroke="none"/>
 <text text-anchor="middle" class="title" clip-path="url(#tc)">
 <textPath href="#ng" startOffset="50%">
-<animate attributeName="startOffset" from="150%" to="-50%" begin="0s" dur="20s" repeatCount="indefinite"></animate>
+<animate attributeName="startOffset" from="180%" to="-80%" begin="0s" dur="20s" repeatCount="indefinite"></animate>
 {{title}}
 </textPath>
 </text>


### PR DESCRIPTION
Fix for #25 

Adds svg based animation for the title element. With this we can handle titles up to ~30-40 characters with the sweet spot being between 20 - 35 characters.

https://user-images.githubusercontent.com/6718506/180796707-e50d79a0-325b-48e4-8fda-c75706543883.mp4


