### PR TITLE
Simplification: Store Stone directly as Angle

### DIFF
--- a/apps/minting-app/components/stonePicker/index.tsx
+++ b/apps/minting-app/components/stonePicker/index.tsx
@@ -44,7 +44,7 @@ const StonePicker: React.FC = () => {
       if (last) {
         dispatch({
           type: "changeStone",
-          value: withoutSkew(Math.floor(pin + delta)),
+          value: Math.round(withoutSkew(pin + delta) * 10),
         });
       }
     }
@@ -114,7 +114,7 @@ const StonePicker: React.FC = () => {
       <div className={styles.stone}>
         <StoneViewer
           seed={state.tokenId}
-          stone={interpolateStone(withoutSkew(Math.floor(rotation)))}
+          stone={interpolateStone(Math.round(withoutSkew(rotation) * 10))}
         />
         <StoneGlass />
       </div>
@@ -157,7 +157,7 @@ const segmentCenters = findSegmentCenters(stoneCount, CONFIG.segment);
 
 function withoutSkew(angle: number) {
   const step = 360 / stoneCount;
-  return Math.round(angle + step * CONFIG.segment.percSkew) % 360;
+  return (angle + step * CONFIG.segment.percSkew) % 360;
 }
 
 function withSkew(angle: number) {

--- a/apps/minting-app/components/stonePicker/index.tsx
+++ b/apps/minting-app/components/stonePicker/index.tsx
@@ -1,12 +1,7 @@
 import { useState, useRef } from "react";
 import { useDrag } from "@use-gesture/react";
 import StoneViewer from "./StoneViewer";
-import {
-  interpolateStone,
-  stoneList,
-  stoneCount,
-  packStoneId,
-} from "../../template";
+import { interpolateStone, stoneList, stoneCount } from "../../template";
 import styles from "./StonePicker.module.css";
 import UiCircle from "../uiCircle";
 import { useAppContext } from "../../state";
@@ -49,7 +44,7 @@ const StonePicker: React.FC = () => {
       if (last) {
         dispatch({
           type: "changeStone",
-          value: toStoneId(withoutSkew(pin + delta)),
+          value: withoutSkew(Math.floor(pin + delta)),
         });
       }
     }
@@ -119,7 +114,7 @@ const StonePicker: React.FC = () => {
       <div className={styles.stone}>
         <StoneViewer
           seed={state.tokenId}
-          stone={interpolateStone(toStoneId(withoutSkew(rotation)))}
+          stone={interpolateStone(withoutSkew(Math.floor(rotation)))}
         />
         <StoneGlass />
       </div>
@@ -170,25 +165,4 @@ function withSkew(angle: number) {
   const result = angle - step * CONFIG.segment.percSkew;
   assert(result >= 0);
   return result;
-}
-
-export function toStoneId(angle: number) {
-  const prevStone = (index: number) => (index > 0 ? index - 1 : stoneCount - 1);
-  const nextStone = (index: number) => (index + 1) % stoneCount;
-
-  const step = 360 / stoneCount;
-  const from = Math.floor(angle / step);
-  const midway = step * from + step / 2;
-
-  if (angle < midway) {
-    // going left
-    const to = prevStone(from);
-    const progress = Math.round(((midway - angle) / step) * 100);
-    return packStoneId(from, to, progress);
-  } else {
-    // going right
-    const to = nextStone(from);
-    const progress = Math.round(((angle - midway) / step) * 100);
-    return packStoneId(from, to, progress);
-  }
 }

--- a/apps/minting-app/components/stonePicker/index.tsx
+++ b/apps/minting-app/components/stonePicker/index.tsx
@@ -44,7 +44,7 @@ const StonePicker: React.FC = () => {
       if (last) {
         dispatch({
           type: "changeStone",
-          value: Math.round(withoutSkew(pin + delta) * 10),
+          value: toStoneId(rotation),
         });
       }
     }
@@ -114,7 +114,7 @@ const StonePicker: React.FC = () => {
       <div className={styles.stone}>
         <StoneViewer
           seed={state.tokenId}
-          stone={interpolateStone(Math.round(withoutSkew(rotation) * 10))}
+          stone={interpolateStone(toStoneId(rotation))}
         />
         <StoneGlass />
       </div>
@@ -155,14 +155,14 @@ const segments = describeSegments(stoneCount, CONFIG.segment);
 const fillers = describeFillers(stoneCount, CONFIG.filler);
 const segmentCenters = findSegmentCenters(stoneCount, CONFIG.segment);
 
-function withoutSkew(angle: number) {
-  const step = 360 / stoneCount;
-  return (angle + step * CONFIG.segment.percSkew) % 360;
+const skew = (360 / stoneCount) * CONFIG.segment.percSkew;
+
+function fromStoneId(stoneId: number) {
+  const toAngleWithSkew = Math.round(stoneId / 10 - skew);
+  return (toAngleWithSkew + 360) % 360;
 }
 
-function withSkew(angle: number) {
-  const step = 360 / stoneCount;
-  const result = angle - step * CONFIG.segment.percSkew;
-  assert(result >= 0);
-  return result;
+function toStoneId(angle: number) {
+  const withoutSkew = (angle + skew) % 360;
+  return (Math.round(withoutSkew) % 360) * 10;
 }

--- a/apps/minting-app/template/stone.ts
+++ b/apps/minting-app/template/stone.ts
@@ -469,7 +469,7 @@ export const stoneList: Stone[] = [
 ];
 
 export function interpolateStone(stoneId: number): Stone {
-  const [from, to, progress] = unpackStoneId(stoneId);
+  const [from, to, progress] = interpolationParams(stoneId);
   const fromStone = stoneList[from];
   const toStone = stoneList[to];
 
@@ -491,31 +491,40 @@ export function interpolateStone(stoneId: number): Stone {
   };
 }
 
+export const stoneCount = stoneList.length;
+const prevStone = (index: number) => (index > 0 ? index - 1 : stoneCount - 1);
+const nextStone = (index: number) => (index + 1) % stoneCount;
+const step = 360 / stoneCount;
+
+export function interpolationParams(angle: number) {
+  // 360 / stoneCount rounded(3)
+  const step = 12.414;
+  const from = Math.floor(angle / step);
+  const midway = step * from + step / 2;
+
+  // console.log("JS:  angle %s", angle);
+  // console.log("JS:  step %s", step);
+  // console.log("JS:  midway %s", midway);
+
+  if (angle < midway) {
+    // console.log("JS:  res %s", ((midway - angle) * 100) / step);
+    // going left
+    const to = prevStone(from);
+    const progress = Math.round(((midway - angle) * 100) / step);
+    return [from, to, progress];
+  } else {
+    // console.log("JS:  res %s", ((angle - midway) * 100) / step);
+    // going right
+    const to = nextStone(from);
+    const progress = Math.round(((angle - midway) * 100) / step);
+    return [from, to, progress];
+  }
+}
+
 function interpolate(from: number, to: number, progress: number) {
   if (from > to) {
     return from - Math.floor(((from - to) * progress) / 100);
   } else {
     return from + Math.floor(((to - from) * progress) / 100);
   }
-}
-
-export const stoneCount = stoneList.length;
-
-export function packStoneId(
-  from: number,
-  to: number,
-  progress: number
-): number {
-  assert(from >= 0 && from < stoneCount);
-  assert(to >= 0 && to < stoneCount);
-  assert(progress >= 0 && progress <= 100);
-  assert(Number.isInteger(from));
-  assert(Number.isInteger(to));
-  assert(Number.isInteger(progress));
-
-  return (from << 12) | (to << 7) | progress;
-}
-
-export function unpackStoneId(stoneId: number) {
-  return [stoneId >> 12, (stoneId & 0xf80) >> 7, stoneId & 0x7f];
 }

--- a/apps/minting-app/template/stone.ts
+++ b/apps/minting-app/template/stone.ts
@@ -494,11 +494,12 @@ export function interpolateStone(stoneId: number): Stone {
 export const stoneCount = stoneList.length;
 const prevStone = (index: number) => (index > 0 ? index - 1 : stoneCount - 1);
 const nextStone = (index: number) => (index + 1) % stoneCount;
-const step = 360 / stoneCount;
+
+// in order for this to exactly match onChain calculation
+// this must be a 3 decimals floored number
+const step = Math.floor((3600 / stoneCount) * 1000) / 1000;
 
 export function interpolationParams(angle: number) {
-  // 360 / stoneCount rounded(3)
-  const step = 124.1379;
   const from = Math.floor(angle / step);
   const midway = step * from + step / 2;
 

--- a/apps/minting-app/template/stone.ts
+++ b/apps/minting-app/template/stone.ts
@@ -498,23 +498,15 @@ const step = 360 / stoneCount;
 
 export function interpolationParams(angle: number) {
   // 360 / stoneCount rounded(3)
-  const step = 12.414;
+  const step = 124.1379;
   const from = Math.floor(angle / step);
   const midway = step * from + step / 2;
 
-  // console.log("JS:  angle %s", angle);
-  // console.log("JS:  step %s", step);
-  // console.log("JS:  midway %s", midway);
-
   if (angle < midway) {
-    // console.log("JS:  res %s", ((midway - angle) * 100) / step);
-    // going left
     const to = prevStone(from);
     const progress = Math.round(((midway - angle) * 100) / step);
     return [from, to, progress];
   } else {
-    // console.log("JS:  res %s", ((angle - midway) * 100) / step);
-    // going right
     const to = nextStone(from);
     const progress = Math.round(((angle - midway) * 100) / step);
     return [from, to, progress];

--- a/contracts/contracts/Wand.sol
+++ b/contracts/contracts/Wand.sol
@@ -16,7 +16,7 @@ contract Wand is ERC721URIStorage, IWands, Ownable {
 
   event WandBuilt(
     uint256 indexed tokenId,
-    uint32 stone,
+    uint16 stone,
     uint8 handle,
     uint16 halo,
     Template.Background background,
@@ -36,7 +36,7 @@ contract Wand is ERC721URIStorage, IWands, Ownable {
 
   function build(
     uint256 tokenId,
-    uint32 stone,
+    uint16 stone,
     uint8 handle,
     uint16 halo,
     Template.Background memory background,

--- a/contracts/contracts/WandConjuror.sol
+++ b/contracts/contracts/WandConjuror.sol
@@ -341,9 +341,9 @@ contract WandConjuror {
       uint8 progress
     )
   {
-    // 12.413793103448276 7 decimals
-    uint256 angle = uint256(stone) * 1000;
-    uint256 step = 12414;
+    // 12.413793103448276
+    uint256 angle = uint256(stone) * 10000;
+    uint256 step = 1241379;
     from = uint8(uint256(angle / step));
     uint256 midway = step * from + step / 2;
 

--- a/contracts/contracts/WandConjuror.sol
+++ b/contracts/contracts/WandConjuror.sol
@@ -264,62 +264,62 @@ contract WandConjuror {
         turbFreqX: interpolateUInt8Value(
           fromStone.turbFreqX,
           toStone.turbFreqX,
-          int256(int8(progress))
+          progress
         ),
         turbFreqY: interpolateUInt8Value(
           fromStone.turbFreqY,
           toStone.turbFreqY,
-          int256(int8(progress))
+          progress
         ),
         turbOct: interpolateUInt8Value(
           fromStone.turbOct,
           toStone.turbOct,
-          int256(int8(progress))
+          progress
         ),
         redAmp: interpolateInt8Value(
           fromStone.redAmp,
           toStone.redAmp,
-          int256(int8(progress))
+          progress
         ),
         redExp: interpolateInt8Value(
           fromStone.redExp,
           toStone.redExp,
-          int256(int8(progress))
+          progress
         ),
         redOff: interpolateInt8Value(
           fromStone.redOff,
           toStone.redOff,
-          int256(int8(progress))
+          progress
         ),
         greenAmp: interpolateInt8Value(
           fromStone.greenAmp,
           toStone.greenAmp,
-          int256(int8(progress))
+          progress
         ),
         greenExp: interpolateInt8Value(
           fromStone.greenExp,
           toStone.greenExp,
-          int256(int8(progress))
+          progress
         ),
         greenOff: interpolateInt8Value(
           fromStone.greenOff,
           toStone.greenOff,
-          int256(int8(progress))
+          progress
         ),
         blueAmp: interpolateInt8Value(
           fromStone.blueAmp,
           toStone.blueAmp,
-          int256(int8(progress))
+          progress
         ),
         blueExp: interpolateInt8Value(
           fromStone.blueExp,
           toStone.blueExp,
-          int256(int8(progress))
+          progress
         ),
         blueOff: interpolateInt8Value(
           fromStone.blueOff,
           toStone.blueOff,
-          int256(int8(progress))
+          progress
         ),
         fractalNoise: progress < 50
           ? fromStone.fractalNoise
@@ -327,7 +327,7 @@ contract WandConjuror {
         rotation: interpolateUInt16Value(
           fromStone.rotation,
           toStone.rotation,
-          int256(int8(progress))
+          progress
         )
       });
   }
@@ -341,20 +341,19 @@ contract WandConjuror {
       uint8 progress
     )
   {
-    // 12.413793103448276
-    uint256 angle = uint256(stone) * 10000;
-    uint256 step = 1241379;
-    from = uint8(uint256(angle / step));
+    uint256 angle = uint256(stone) * 1000;
+    uint256 step = 3600 * 1000 / stoneList().length;
+    from = uint8(angle / step);
     uint256 midway = step * from + step / 2;
 
     if (angle < midway) {
       // going left
       to = prevStone(from);
-      progress = uint8(round((((midway - angle) * 10000) / step), 2));
+      progress = uint8(round1(((midway - angle) * 1000) / step));
     } else {
       // going right
       to = nextStone(from);
-      progress = uint8(round((((angle - midway) * 10000) / step), 2));
+      progress = uint8(round1(((angle - midway) * 1000) / step));
     }
   }
 
@@ -366,43 +365,34 @@ contract WandConjuror {
     return (index + 1) % uint8(stoneList().length);
   }
 
-  function round(uint256 number, uint8 decimals)
-    internal
-    pure
-    returns (uint256)
-  {
-    uint256 digits;
-    for (uint8 d = 0; d < decimals; d++) {
-      uint256 digit = (number / (10**d)) % 10;
-      digits += uint256(digit * (10**d));
-    }
-
-    bool up = digits >= (10**decimals) / 2;
-    return uint256(number / 10**decimals + (up ? 1 : 0));
+  function round1(uint256 number) internal pure returns (uint256) {
+    return number / 10 + ((number % 10) >= 5 ? 1 : 0);
   }
 
   function interpolateUInt8Value(
     uint8 from,
     uint8 to,
-    int256 progress
+    uint8 progress
   ) internal pure returns (uint8) {
-    return uint8(uint256(interpolateValue(int8(from), int8(to), progress)));
+    return
+      uint8(uint256(interpolateValue(int8(from), int8(to), int8(progress))));
   }
 
   function interpolateUInt16Value(
     uint16 from,
     uint16 to,
-    int256 progress
+    uint8 progress
   ) internal pure returns (uint16) {
-    return uint16(uint256(interpolateValue(int16(from), int16(to), progress)));
+    return
+      uint16(uint256(interpolateValue(int16(from), int16(to), int8(progress))));
   }
 
   function interpolateInt8Value(
     int8 from,
     int8 to,
-    int256 progress
+    uint8 progress
   ) internal pure returns (int8) {
-    return int8(interpolateValue(from, to, progress));
+    return int8(interpolateValue(from, to, int8(progress)));
   }
 
   function interpolateValue(

--- a/contracts/contracts/interfaces/IWands.sol
+++ b/contracts/contracts/interfaces/IWands.sol
@@ -21,7 +21,7 @@ interface IWands is IERC721 {
 
   struct Wand {
     bool built;
-    uint32 stone;
+    uint16 stone;
     uint8 handle;
     uint16 halo;
     uint32 evolution;
@@ -33,7 +33,7 @@ interface IWands is IERC721 {
 
   function build(
     uint256 tokenId,
-    uint32 stone,
+    uint16 stone,
     uint8 handle,
     uint16 halo,
     Template.Background memory background,

--- a/contracts/contracts/test/WandConjurorExposer.sol
+++ b/contracts/contracts/test/WandConjurorExposer.sol
@@ -6,7 +6,7 @@ import "../WandConjuror.sol";
 contract WandConjurorExposer is WandConjuror {
   // contract makes internal functions public for test setup
 
-  function _interpolateStone(uint32 stoneId)
+  function _interpolateStone(uint16 stoneId)
     public
     pure
     returns (Template.Stone memory)
@@ -14,7 +14,7 @@ contract WandConjurorExposer is WandConjuror {
     return interpolateStone(stoneId);
   }
 
-  function _unpackStoneId(uint32 stoneId)
+  function _interpolationParams(uint16 stoneId)
     public
     pure
     returns (
@@ -23,9 +23,6 @@ contract WandConjurorExposer is WandConjuror {
       uint8 progress
     )
   {
-    int256 p;
-    (from, to, p) = unpackStoneId(stoneId);
-
-    progress = uint8(uint256(p));
+    return interpolationParams(stoneId);
   }
 }

--- a/contracts/test/WandConjuror.spec.ts
+++ b/contracts/test/WandConjuror.spec.ts
@@ -84,6 +84,7 @@ describe("WandConjuror", async () => {
       //   await checkIt(stoneId);
       // }
 
+      //random values
       await checkIt(3210);
       await checkIt(3014);
       await checkIt(2794);
@@ -96,7 +97,7 @@ describe("WandConjuror", async () => {
       await checkIt(2930);
     });
 
-    it("compares interpolation param calculation in Solidity vs JavaScript", async () => {
+    it("compares param for interpolation calculation in Solidity vs JavaScript", async () => {
       const { wandConjurorExposer } = await baseSetup();
 
       const checkIt = async (stoneId: number) => {

--- a/contracts/test/WandConjuror.spec.ts
+++ b/contracts/test/WandConjuror.spec.ts
@@ -4,8 +4,7 @@ import "@nomiclabs/hardhat-ethers";
 
 import {
   interpolateStone,
-  packStoneId,
-  unpackStoneId,
+  interpolationParams,
 } from "../../apps/minting-app/template";
 
 describe("WandConjuror", async () => {
@@ -57,8 +56,7 @@ describe("WandConjuror", async () => {
     it("compares interpolated stone in Solidity vs JavaScript", async () => {
       const { wandConjurorExposer } = await baseSetup();
 
-      const checkIt = async (from: number, to: number, progress: number) => {
-        const stoneId = packStoneId(from, to, progress);
+      const checkIt = async (stoneId: number) => {
         const fromSolidity = await wandConjurorExposer._interpolateStone(
           stoneId
         );
@@ -80,81 +78,35 @@ describe("WandConjuror", async () => {
         expect(fromJS.rotation).to.equal(fromSolidity.rotation);
       };
 
-      // cycling through all takes time
-      // for (let from = 0; from < 29; from++) {
-      //   for (let to = from; to < 29; to++) {
-      //     for (let progress = 0; progress <= 100; progress++) {
-      //       console.log(from, to, progress);
-      //       await checkIt(from, to, progress);
-      //     }
-      //   }
-      // }
-
       // random values
-      checkIt(26, 11, 61);
-      checkIt(23, 27, 45);
-      checkIt(13, 4, 79);
-      checkIt(2, 14, 76);
-      checkIt(1, 12, 92);
-      checkIt(14, 22, 82);
-      checkIt(0, 12, 2);
-      checkIt(22, 17, 30);
-      checkIt(7, 7, 5);
+      for (let i = 0; i < 360; i++) {
+        checkIt(i);
+      }
     });
 
-    it("compares stoneId extraction in Solidity vs JavaScript", async () => {
+    it.skip("compares stoneId extraction in Solidity vs JavaScript", async () => {
       const { wandConjurorExposer } = await baseSetup();
 
-      const checkIt = async (from: number, to: number, progress: number) => {
-        const stoneId = packStoneId(from, to, progress);
-
+      const checkIt = async (stoneId: number) => {
         const {
           from: solFrom,
           to: solTo,
           progress: solProgress,
-        } = await wandConjurorExposer._unpackStoneId(stoneId);
-
-        const [jsFrom, jsTo, jsProgress] = unpackStoneId(stoneId);
-
+        } = await wandConjurorExposer._interpolationParams(stoneId);
+        const [jsFrom, jsTo, jsProgress] = interpolationParams(stoneId);
+        // console.log(stoneId);
+        // console.log(solFrom, solTo);
+        // console.log(jsFrom, jsTo);
+        // console.log(jsProgress, solProgress);
         expect(solFrom).to.equal(jsFrom);
         expect(solTo).to.equal(jsTo);
         expect(solProgress).to.equal(jsProgress);
-        expect(from).to.equal(jsFrom);
-        expect(to).to.equal(jsTo);
-        expect(progress).to.equal(jsProgress);
       };
 
       // cycling through all takes time
-      // for (let from = 0; from < 29; from++) {
-      //   for (let to = from; to < 29; to++) {
-      //     for (let progress = 0; progress <= 100; progress++) {
-      //       console.log(from, to, progress);
-      //       await checkIt(from, to, progress);
-      //     }
-      //   }
-      // }
-
-      // random values
-      checkIt(28, 22, 53);
-      checkIt(23, 14, 88);
-      checkIt(5, 0, 86);
-      checkIt(20, 27, 22);
-      checkIt(23, 23, 48);
-      checkIt(21, 27, 88);
-      checkIt(19, 10, 49);
-      checkIt(2, 4, 45);
-      checkIt(4, 25, 85);
-      checkIt(14, 9, 65);
-
-      checkIt(0, 1, 10);
-      checkIt(0, 1, 50);
-      checkIt(0, 1, 99);
-      checkIt(0, 28, 2);
-      checkIt(0, 28, 45);
-      checkIt(0, 28, 97);
-      checkIt(15, 16, 0);
-      checkIt(15, 16, 30);
-      checkIt(15, 16, 50);
+      for (let stoneId = 0; stoneId < 360; stoneId++) {
+        await checkIt(stoneId);
+      }
     });
   });
 });

--- a/contracts/test/WandConjuror.spec.ts
+++ b/contracts/test/WandConjuror.spec.ts
@@ -78,13 +78,25 @@ describe("WandConjuror", async () => {
         expect(fromJS.rotation).to.equal(fromSolidity.rotation);
       };
 
-      // random values
-      for (let i = 0; i < 360; i++) {
-        checkIt(i);
-      }
+      // cycling through all takes time
+      // for (let stoneId = 0; stoneId < 3600; stoneId++) {
+      //   console.log(stoneId);
+      //   await checkIt(stoneId);
+      // }
+
+      await checkIt(3210);
+      await checkIt(3014);
+      await checkIt(2794);
+      await checkIt(1242);
+      await checkIt(355);
+      await checkIt(297);
+      await checkIt(2765);
+      await checkIt(104);
+      await checkIt(826);
+      await checkIt(2930);
     });
 
-    it.skip("compares stoneId extraction in Solidity vs JavaScript", async () => {
+    it("compares interpolation param calculation in Solidity vs JavaScript", async () => {
       const { wandConjurorExposer } = await baseSetup();
 
       const checkIt = async (stoneId: number) => {
@@ -103,10 +115,23 @@ describe("WandConjuror", async () => {
         expect(solProgress).to.equal(jsProgress);
       };
 
-      // cycling through all takes time
-      for (let stoneId = 0; stoneId < 360; stoneId++) {
-        await checkIt(stoneId);
-      }
+      // // cycling through all takes time
+      // for (let stoneId = 0; stoneId < 3600; stoneId++) {
+      //   console.log(stoneId);
+      //   await checkIt(stoneId);
+      // }
+
+      // random values
+      await checkIt(1251);
+      await checkIt(1318);
+      await checkIt(1137);
+      await checkIt(3016);
+      await checkIt(1813);
+      await checkIt(3058);
+      await checkIt(216);
+      await checkIt(1550);
+      await checkIt(2820);
+      await checkIt(2569);
     });
   });
 });


### PR DESCRIPTION
When calculating stone interpolation, we derive fromIndex toIndex and progress from an angle in degrees.

Given that solidity does not support decimal numbers, I originally couldn't replicate computation on chain. So decided to store from, to and progress packed in an uint32

This PR removes this indirection, by storing the angle directly, and performing the parameter computation on chain.

NOTE: This is also expanding the amount of stone configurations possible. We are storing a number between 0 and 3600 which effectively means: angle in degrees with one decimal place.

Therefore:
* Before -> 360 distinct stone options
* Now -> 3600 distinct stone options