### PR TITLE
Streamline halo/handle packing/unpacking

### DIFF
--- a/apps/minting-app/components/MintButton/index.tsx
+++ b/apps/minting-app/components/MintButton/index.tsx
@@ -2,7 +2,12 @@ import { ethers } from "ethers";
 import { getAddress } from "ethers/lib/utils";
 import { useContractWrite, usePrepareContractWrite } from "wagmi";
 import { useAppContext } from "../../state";
-import { calculateAspects, calculatePlanets, encodeHalo } from "../../template";
+import {
+  calculateAspects,
+  calculatePlanets,
+  generateHalo,
+  generateHandle,
+} from "../../template";
 import { AppState } from "../../types";
 import styles from "./MintButton.module.css";
 
@@ -12,12 +17,12 @@ interface Props {
 }
 
 const WANDS = {
-  address: getAddress("0xeDDCA997eFBfC061fE497C8cb5644EfF6DE8C9dD"),
+  address: getAddress("0xf61812a9afe6992Ac91575830333355355092D9e"),
   abi: [
-    "function mint(uint16 stone, uint8 handle, uint16 halo, tuple(bool radial, bool dark, tuple(uint8 saturation, uint8 lightness, uint16 hue) color) background, tuple(bool visible, int8 x, int8 y)[8] planets, tuple(int8 x1, int8 y1, int8 x2, int8 y2)[8] aspects) returns (uint256)",
+    "function mint(uint16 stone, tuple(bool handle0, bool handle1, bool handle2, bool handle3) handle, tuple(bool halo0, bool halo1, bool halo2, bool halo3, bool halo4, bool halo5, uint16 hue, bool[24] rhythm) halo, tuple(bool radial, bool dark, tuple(uint8 saturation, uint8 lightness, uint16 hue) color) background, tuple(bool visible, int8 x, int8 y)[8] planets, tuple(int8 x1, int8 y1, int8 x2, int8 y2)[8] aspects) returns (uint256)",
   ],
   iface: new ethers.utils.Interface([
-    "function mint(uint16 stone, uint8 handle, uint16 halo, tuple(bool radial, bool dark, tuple(uint8 saturation, uint8 lightness, uint16 hue) color) background, tuple(bool visible, int8 x, int8 y)[8] planets, tuple(int8 x1, int8 y1, int8 x2, int8 y2)[8] aspects) returns (uint256)",
+    "function mint(uint16 stone, tuple(bool handle0, bool handle1, bool handle2, bool handle3) handle, tuple(bool halo0, bool halo1, bool halo2, bool halo3, bool halo4, bool halo5, uint16 hue, bool[24] rhythm) halo, tuple(bool radial, bool dark, tuple(uint8 saturation, uint8 lightness, uint16 hue) color) background, tuple(bool visible, int8 x, int8 y)[8] planets, tuple(int8 x1, int8 y1, int8 x2, int8 y2)[8] aspects) returns (uint256)",
   ]),
 };
 
@@ -48,8 +53,12 @@ const MintButton: React.FC<Props> = ({ onClick, inactive }) => {
 function writeArgs(state: AppState) {
   return [
     state.stone,
-    state.handle,
-    encodeHalo(state.halo.shape, state.halo.rhythm),
+    generateHandle(state.handle),
+    generateHalo(
+      state.halo.shape,
+      state.halo.rhythm,
+      state.background.color.hue
+    ),
     state.background,
     calculatePlanets(
       state.latitude,

--- a/apps/minting-app/template/halo.ts
+++ b/apps/minting-app/template/halo.ts
@@ -24,18 +24,3 @@ const mirrorRhythm = (rhythm: boolean[], isWide: boolean) => {
 };
 
 export const isWideShape = (shape: ShapeId) => ![1, 5].includes(shape);
-
-export const encodeHalo = (shapeId: ShapeId, rhythm: boolean[]) => {
-  if (rhythm.length !== 13) throw new Error("Rhythm must have length 13");
-  const isWide = isWideShape(shapeId);
-  return parseInt(
-    rhythm
-      .map((x, index) => {
-        const oddIndex = index % 2 === 0;
-        return x && !(isWide && oddIndex) ? "1" : "0";
-      })
-      .reverse()
-      .join("") + shapeId.toString(2).padStart(3, "0"),
-    2
-  );
-};

--- a/contracts/contracts/Conjuror.sol
+++ b/contracts/contracts/Conjuror.sol
@@ -70,58 +70,19 @@ contract Conjuror is IConjuror {
           seed: wand.tokenId,
           planets: scalePlanets(wand.planets),
           aspects: scaleAspects(wand.aspects),
-          handle: Template.Handle({
-            handle0: wand.handle == 0,
-            handle1: wand.handle == 1,
-            handle2: wand.handle == 2,
-            handle3: wand.handle == 3
-          }),
+          handle: wand.handle,
           xp: Template.Xp({
             cap: xpCap,
             amount: wand.xp,
             crown: wand.xp >= xpCap
           }),
-          stone: decodeStone(wand),
-          halo: decodeHalo(wand),
+          stone: interpolateStone(wand.stone),
+          halo: wand.halo,
           frame: generateFrame(wand, name),
           sparkles: generateSparkles(wand.tokenId),
           filterLayers: generateFilterLayers()
         })
       );
-  }
-
-  function decodeStone(Wand memory wand)
-    internal
-    pure
-    returns (Template.Stone memory)
-  {
-    return interpolateStone(wand.stone);
-  }
-
-  function decodeHalo(Wand memory wand)
-    internal
-    pure
-    returns (Template.Halo memory)
-  {
-    uint256 rhythmBits = wand.halo >> 3; // first 13 bits give the rhythm
-    uint256 shape = wand.halo % rhythmBits; // remaining 3 bits are the halo shape index
-    bool[24] memory rhythm;
-    for (uint256 i = 0; i < 24; i++) {
-      uint256 bit = i > 12 ? 24 - i : i; // rhythm repeats backwards after 13 beats
-      rhythm[i] = (1 << bit) & rhythmBits > 0;
-    }
-
-    return
-      Template.Halo({
-        halo0: shape == 0,
-        halo1: shape == 1,
-        halo2: shape == 2,
-        halo3: shape == 3,
-        halo4: shape == 4,
-        halo5: shape == 5,
-        hue: (wand.background.color.hue + 180) % 360,
-        rhythm: rhythm
-      });
   }
 
   function generateFrame(Wand memory wand, string memory name)

--- a/contracts/contracts/ZodiacWands.sol
+++ b/contracts/contracts/ZodiacWands.sol
@@ -1,46 +1,44 @@
-                                                                                                                                                  
-//      ****           *                 **                                       ***** *    **   ***                                 **              
-//     *  *************                   **     *                             ******  *  *****    ***                                 **             
-//    *     **********                    **    ***                           **   *  *     *****   ***                                **             
-//    *             *                     **     *                           *    *  **     * **      **                               **             
-//     **          *        ****          **                                     *  ***     *         **                               **      ****   
+//      ****           *                 **                                       ***** *    **   ***                                 **
+//     *  *************                   **     *                             ******  *  *****    ***                                 **
+//    *     **********                    **    ***                           **   *  *     *****   ***                                **
+//    *             *                     **     *                           *    *  **     * **      **                               **
+//     **          *        ****          **                                     *  ***     *         **                               **      ****
 //                *        * ***  *   *** **   ***        ****       ****       **   **     *         **    ****    ***  ****      *** **     * **** *
-//               *        *   ****   *********  ***      * ***  *   * ***  *    **   **     *         **   * ***  *  **** **** *  *********  **  **** 
-//              *        **    **   **   ****    **     *   ****   *   ****     **   **     *         **  *   ****    **   ****  **   ****  ****      
-//             *         **    **   **    **     **    **    **   **            **   **     *         ** **    **     **    **   **    **     ***     
-//            *          **    **   **    **     **    **    **   **            **   **     *         ** **    **     **    **   **    **       ***   
-//           *           **    **   **    **     **    **    **   **             **  **     *         ** **    **     **    **   **    **         *** 
-//          *            **    **   **    **     **    **    **   **              ** *      *         *  **    **     **    **   **    **    ****  ** 
-//      ****           *  ******    **    **     **    **    **   ***     *        ***      ***      *   **    **     **    **   **    **   * **** *  
-//     *  *************    ****      *****       *** *  ***** **   *******          ******** ********     ***** **    ***   ***   *****        ****   
-//    *     **********                ***         ***    ***   **   *****             ****     ****        ***   **    ***   ***   ***    
-// 
-// 
-//                              ...             ...                         
-//                             .*%&*..       .,*&&*.                        
-//                            .*%&&&&&/*,,,*/%&&%&&*.                       
-//               ,         ..,%%&&%%&#/*,.,*/%&&%&&&(,..                    
-//                ,%&%////%%/,,,*/%&%*.     .*&%%/*,,,(%%////#&%,           
-//                .*%&%&&&(,. .   .,%.,     ,.#,.   . .*#&&%%&&*.           
+//               *        *   ****   *********  ***      * ***  *   * ***  *    **   **     *         **   * ***  *  **** **** *  *********  **  ****
+//              *        **    **   **   ****    **     *   ****   *   ****     **   **     *         **  *   ****    **   ****  **   ****  ****
+//             *         **    **   **    **     **    **    **   **            **   **     *         ** **    **     **    **   **    **     ***
+//            *          **    **   **    **     **    **    **   **            **   **     *         ** **    **     **    **   **    **       ***
+//           *           **    **   **    **     **    **    **   **             **  **     *         ** **    **     **    **   **    **         ***
+//          *            **    **   **    **     **    **    **   **              ** *      *         *  **    **     **    **   **    **    ****  **
+//      ****           *  ******    **    **     **    **    **   ***     *        ***      ***      *   **    **     **    **   **    **   * **** *
+//     *  *************    ****      *****       *** *  ***** **   *******          ******** ********     ***** **    ***   ***   *****        ****
+//    *     **********                ***         ***    ***   **   *****             ****     ****        ***   **    ***   ***   ***
+//
+//
+//                              ...             ...
+//                             .*%&*..       .,*&&*.
+//                            .*%&&&&&/*,,,*/%&&%&&*.
+//               ,         ..,%%&&%%&#/*,.,*/%&&%&&&(,..
+//                ,%&%////%%/,,,*/%&%*.     .*&%%/*,,,(%%////#&%,
+//                .*%&%&&&(,. .   .,%.,     ,.#,.   . .*#&&%%&&*.
 //                .*%&&&&&%,.                         .,%&%&&&&*.                       ‘O most honored Greening Force, You who roots in the Sun;
 //               .,##***,**#.     .    .*%,.    ..    ,%**,,**&(,                        You who lights up, in shining serenity, within a wheel
 //             .,*&*.            ,.,.,,*//**,.,..            ..*%*,.                     that earthly excellence fails to comprehend.
-//        .,*/%&&&#/,   ,   .  .*,/((###%%%#####/,,.      .   ./&&&%(**,.            
+//        .,*/%&&&#/,   ,   .  .*,/((###%%%#####/,,.      .   ./&&&%(**,.
 //        .,/%&%&#%&#*..     .,,//((#%&&&&&%%%%%###,,.     ,.*%&&&%&%&*,.                You are enfolded
 //          .,(%&%(*,,..    ,,**//(((##%&&&&&%%%%###,/,    ..,,*(#%&(,.                  in the weaving of divine mysteries.
-//           .,%/,.     ,  ,,,**///((####%%&&%&%%%###,,         .,#%,       
+//           .,%/,.     ,  ,,,**///((####%%&&%&%%%###,,         .,#%,
 //            ,%*.         ,,,(((///(((#####%%%%%##%#,,          ,/#,                    You redden like the dawn
 //           ,/&%(*,..,  .  ,.**(/////@((((((#####&#*.,     ...,*#&%*,                   and you burn: flame of the Sun.”
-//         .*&&%&#%&&(,.     ,.*////////&/(/((((#%%*.,     .,%%%&&%&&#*.    
+//         .*&&%&#%&&(,.     ,.*////////&/(/((((#%%*.,     .,%%%&&%&&#*.
 //       /((%%&&&&&/,         .,.*(((((///(((#(#(*.,,        .*/%&&&&&%##,               –  Hildegard von Bingen, Causae et Curae
-//            .,*%%*.,.          ,,.,*(((((((*,.,,          . .*&#*..       
-//               .*%*,.....*.        ,,*/%#*,    ,    .......,*%*.          
-//                .*&%&%%(,.         .,*,(/(,,         .,%&&&&%*.           
-//                .*&&&*,           ..,*(#//, .    .     .,/#%%,.           
-//                .#/,.       .       .**#/*.       .       .,%*.           
-//                                    .**#/,.              .                
-//                                    .,./*,,                                       
-
+//            .,*%%*.,.          ,,.,*(((((((*,.,,          . .*&#*..
+//               .*%*,.....*.        ,,*/%#*,    ,    .......,*%*.
+//                .*&%&%%(,.         .,*,(/(,,         .,%&&&&%*.
+//                .*&&&*,           ..,*(#//, .    .     .,/#%%,.
+//                .#/,.       .       .**#/*.       .       .,%*.
+//                                    .**#/,.              .
+//                                    .,./*,,
 
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.6;
@@ -61,8 +59,8 @@ contract ZodiacWands is IZodiacWands, ERC721, Ownable {
   event WandBuilt(
     uint256 indexed tokenId,
     uint16 stone,
-    uint8 handle,
-    uint16 halo,
+    Template.Handle handle,
+    Template.Halo halo,
     Template.Background background,
     Planet[8] planets,
     Aspect[8] aspects
@@ -74,8 +72,8 @@ contract ZodiacWands is IZodiacWands, ERC721, Ownable {
 
   function mint(
     uint16 stone,
-    uint8 handle,
-    uint16 halo,
+    Template.Handle memory handle,
+    Template.Halo memory halo,
     Template.Background memory background,
     Planet[8] memory planets,
     Aspect[8] memory aspects
@@ -84,10 +82,10 @@ contract ZodiacWands is IZodiacWands, ERC721, Ownable {
     _safeMint(msg.sender, tokenId);
 
     wands[tokenId] = pack(
+      uint64(block.timestamp),
       stone,
       handle,
       halo,
-      uint64(block.timestamp),
       background,
       planets,
       aspects
@@ -115,17 +113,19 @@ contract ZodiacWands is IZodiacWands, ERC721, Ownable {
   }
 
   function pack(
-    uint16 stone,
-    uint8 handle,
-    uint16 halo,
     uint64 birth,
+    uint16 stone,
+    Template.Handle memory handle,
+    Template.Halo memory halo,
     Template.Background memory background,
     Planet[8] memory planets,
     Aspect[8] memory aspects
   ) internal pure returns (PackedWand memory) {
-    (uint128 packedPlanets, uint8 visibility) = packPlanets(planets);
+    (uint128 packedPlanets, uint8 packedVisibility) = packPlanets(planets);
     uint256 packedAspects = packAspects(aspects);
     uint64 packedBackground = packBackground(background);
+    uint16 packedHalo = packHalo(halo);
+    uint8 packedHandle = packHandle(handle);
 
     return
       PackedWand({
@@ -134,9 +134,9 @@ contract ZodiacWands is IZodiacWands, ERC721, Ownable {
         planets: packedPlanets,
         aspects: packedAspects,
         stone: stone,
-        halo: halo,
-        visibility: visibility,
-        handle: handle
+        halo: packedHalo,
+        visibility: packedVisibility,
+        handle: packedHandle
       });
   }
 
@@ -145,14 +145,20 @@ contract ZodiacWands is IZodiacWands, ERC721, Ownable {
     view
     returns (Wand memory)
   {
+    Template.Background memory background = unpackBackground(
+      packedWand.background
+    );
+    Template.Halo memory halo = unpackHalo(packedWand.halo);
+    halo.hue = (background.color.hue + 180) % 360;
+
     return
       Wand({
         tokenId: tokenId,
         stone: packedWand.stone,
-        halo: packedWand.halo,
+        halo: halo,
         birth: packedWand.birth,
-        handle: packedWand.handle,
-        background: unpackBackground(packedWand.background),
+        handle: unpackHandle(packedWand.handle),
+        background: background,
         planets: unpackPlanets(packedWand.planets, packedWand.visibility),
         aspects: unpackAspects(packedWand.aspects),
         xp: address(forge) != address(0)
@@ -248,5 +254,87 @@ contract ZodiacWands is IZodiacWands, ERC721, Ownable {
     background.color.saturation = uint8(packedBackground >> 2);
     background.color.lightness = uint8(packedBackground >> 10);
     background.color.hue = uint16(packedBackground >> 18);
+  }
+
+  function packHalo(Template.Halo memory halo)
+    internal
+    pure
+    returns (uint16 packedHalo)
+  {
+    uint8 shape;
+    if (halo.halo0) {
+      shape = 0;
+    } else if (halo.halo1) {
+      shape = 1;
+    } else if (halo.halo2) {
+      shape = 2;
+    } else if (halo.halo3) {
+      shape = 3;
+    } else if (halo.halo4) {
+      shape = 4;
+    } else if (halo.halo5) {
+      shape = 5;
+    }
+    uint16 rhythm;
+    for (uint256 i = 0; i < 13; i++) {
+      rhythm |= uint16((halo.rhythm[i] ? 1 : 0)) << uint16(i);
+    }
+
+    return (rhythm << 3) | shape;
+  }
+
+  function unpackHalo(uint16 packedHalo)
+    internal
+    pure
+    returns (Template.Halo memory halo)
+  {
+    bool[24] memory rhythm;
+    for (uint256 i = 0; i < 24; i++) {
+      uint256 bit = i > 12 ? 24 - i : i;
+      rhythm[i] = ((1 << bit) & (packedHalo >> 3)) != 0;
+    }
+    uint8 shape = uint8(packedHalo) & 0x07;
+
+    return
+      Template.Halo({
+        halo0: shape == 0,
+        halo1: shape == 1,
+        halo2: shape == 2,
+        halo3: shape == 3,
+        halo4: shape == 4,
+        halo5: shape == 5,
+        hue: 0, //(wand.background.color.hue + 180) % 360,
+        rhythm: rhythm
+      });
+  }
+
+  function packHandle(Template.Handle memory handle)
+    internal
+    pure
+    returns (uint8 packedHandle)
+  {
+    if (handle.handle0) {
+      packedHandle = uint8(0);
+    } else if (handle.handle1) {
+      packedHandle = uint8(1);
+    } else if (handle.handle2) {
+      packedHandle = uint8(2);
+    } else if (handle.handle3) {
+      packedHandle = uint8(3);
+    }
+  }
+
+  function unpackHandle(uint8 packedHandle)
+    internal
+    pure
+    returns (Template.Handle memory handle)
+  {
+    return
+      Template.Handle({
+        handle0: packedHandle == 0,
+        handle1: packedHandle == 1,
+        handle2: packedHandle == 2,
+        handle3: packedHandle == 3
+      });
   }
 }

--- a/contracts/contracts/interfaces/IZodiacWands.sol
+++ b/contracts/contracts/interfaces/IZodiacWands.sol
@@ -7,8 +7,8 @@ import "./Types.sol";
 interface IZodiacWands is IERC721 {
   function mint(
     uint16 stone,
-    uint8 handle,
-    uint16 halo,
+    Template.Handle memory handle,
+    Template.Halo memory halo,
     Template.Background memory background,
     Planet[8] memory planets,
     Aspect[8] memory aspects

--- a/contracts/contracts/interfaces/Types.sol
+++ b/contracts/contracts/interfaces/Types.sol
@@ -18,10 +18,10 @@ struct Planet {
 
 struct Wand {
   uint256 tokenId;
-  uint16 stone;
-  uint16 halo;
   uint64 birth;
-  uint8 handle;
+  uint16 stone;
+  Template.Halo halo;
+  Template.Handle handle;
   Template.Background background;
   Planet[8] planets;
   Aspect[8] aspects;

--- a/contracts/test/ZodiacWands.spec.ts
+++ b/contracts/test/ZodiacWands.spec.ts
@@ -3,7 +3,6 @@ import hre, { deployments, waffle } from "hardhat";
 import "@nomiclabs/hardhat-ethers";
 
 import {
-  encodeHalo,
   calculatePlanets,
   calculateAspects,
   scalePlanets,
@@ -87,8 +86,8 @@ describe("ZodiacWands", async () => {
 
       const tx = await zodiacWands.mint(
         stone,
-        handle,
-        encodeHalo(haloShape, haloRhythm),
+        generateHandle(handle),
+        generateHalo(haloShape, haloRhythm, background.color.hue),
         background,
         planets,
         aspects


### PR DESCRIPTION
On our very first version of Wands deployed to rinkeby we ran into some decoding issues.

Leverage our pack/unpack architecture to streamline the way we are passing halo/handle arguments to mint, and how we are unpacking them for render.