### PR TITLE
Advance leveling implementation

### DIFF
--- a/contracts/contracts/Conjuror.sol
+++ b/contracts/contracts/Conjuror.sol
@@ -46,9 +46,9 @@ contract Conjuror is IConjuror {
       string(
         abi.encodePacked(
           '{"trait_type": "Level", "value": ',
-          SolidMustacheHelpers.uintToString(wand.level, 0),
+          SolidMustacheHelpers.uintToString(wand.level + 1, 0),
           '},{"trait_type": "Evolution", "value": ',
-          SolidMustacheHelpers.uintToString(wand.xp, 0),
+          SolidMustacheHelpers.uintToString(wand.xp.amount, 0),
           '},{"trait_type": "Birth", "display_type": "date", "value": ',
           SolidMustacheHelpers.uintToString(wand.birth, 0),
           "}"
@@ -61,8 +61,6 @@ contract Conjuror is IConjuror {
     string memory name,
     address owner
   ) internal pure returns (string memory svg) {
-    // TODO should xpCap be pulled from the forge?
-    uint32 xpCap = 10000;
     return
       Cauldron.render(
         Cauldron.__Input({
@@ -71,11 +69,7 @@ contract Conjuror is IConjuror {
           planets: scalePlanets(wand.planets),
           aspects: scaleAspects(wand.aspects),
           handle: wand.handle,
-          xp: Cauldron.Xp({
-            cap: xpCap,
-            amount: wand.xp,
-            crown: wand.xp >= xpCap
-          }),
+          xp: wand.xp,
           stone: interpolateStone(wand.stone),
           halo: wand.halo,
           frame: generateFrame(wand, name),

--- a/contracts/contracts/Decanter.sol
+++ b/contracts/contracts/Decanter.sol
@@ -30,11 +30,7 @@ library Decanter {
         planets: unpackPlanets(packedWand.planets, packedWand.visibility),
         aspects: unpackAspects(packedWand.aspects),
         level: 0,
-        xp: Cauldron.Xp({
-          amount: 0,
-          cap: 0,
-          crown: false
-        })
+        xp: Cauldron.Xp({amount: 0, cap: 0, crown: false})
       });
   }
 

--- a/contracts/contracts/Decanter.sol
+++ b/contracts/contracts/Decanter.sol
@@ -96,7 +96,7 @@ library Decanter {
         halo3: shape == 3,
         halo4: shape == 4,
         halo5: shape == 5,
-        hue: 0, //(wand.background.color.hue + 180) % 360,
+        hue: 0, // will be updated afterwards in unpack
         rhythm: rhythm
       });
   }

--- a/contracts/contracts/Decanter.sol
+++ b/contracts/contracts/Decanter.sol
@@ -29,10 +29,11 @@ library Decanter {
         background: background,
         planets: unpackPlanets(packedWand.planets, packedWand.visibility),
         aspects: unpackAspects(packedWand.aspects),
+        level: 0,
         xp: Cauldron.Xp({
-          level: 0,
-          xp: 0,
-          xpSpent: 0
+          amount: 0,
+          cap: 0,
+          crown: false
         })
       });
   }

--- a/contracts/contracts/Decanter.sol
+++ b/contracts/contracts/Decanter.sol
@@ -29,8 +29,11 @@ library Decanter {
         background: background,
         planets: unpackPlanets(packedWand.planets, packedWand.visibility),
         aspects: unpackAspects(packedWand.aspects),
-        xp: 0,
-        level: 0
+        xp: Cauldron.Xp({
+          level: 0,
+          xp: 0,
+          xpSpent: 0
+        })
       });
   }
 

--- a/contracts/contracts/Forge.sol
+++ b/contracts/contracts/Forge.sol
@@ -9,11 +9,11 @@ interface ITrackOwnership {
 }
 
 contract Forge is IForge, Ownable {
-  uint32[] override public nextLevelXp; // array of xp cost for upgrading to the respective levels
+  uint32[] public override nextLevelXp; // array of xp cost for upgrading to the respective levels
 
-  mapping(uint256 => uint8) override public level; // wand tokenId -> level
-  mapping(address => uint32) override public xp; // account -> total gained XP
-  mapping(address => uint32) override public xpSpent; // account -> XP that has been redeemed for leveling up wands
+  mapping(uint256 => uint8) public override level; // wand tokenId -> level
+  mapping(address => uint32) public override xp; // account -> total gained XP
+  mapping(address => uint32) public override xpSpent; // account -> XP that has been redeemed for leveling up wands
 
   ITrackOwnership public immutable wand;
 
@@ -22,14 +22,14 @@ contract Forge is IForge, Ownable {
     nextLevelXp = _levels;
   }
 
-  function levelUp(uint256 _tokenId, uint8 _toLevel) override external {
+  function levelUp(uint256 _tokenId, uint8 _toLevel) external override {
     require(wand.ownerOf(_tokenId) == msg.sender, "Not your wand");
     require(_toLevel > level[_tokenId], "Already at or above that level");
     require(_toLevel <= nextLevelXp.length, "Level out of bounds");
 
     uint32 availableXp = xp[msg.sender] - xpSpent[msg.sender];
-    for(uint8 i = level[_tokenId] + 1; i <= _toLevel; i++) {
-      uint32 levelCost = nextLevelXp[i-1]; // -1 because level 0 is the default and not listed in the nextLevelXp cost array
+    for (uint8 i = level[_tokenId] + 1; i <= _toLevel; i++) {
+      uint32 levelCost = nextLevelXp[i - 1]; // -1 because level 0 is the default and not listed in the nextLevelXp cost array
       require(availableXp >= levelCost, "Not enough XP to spend");
       availableXp -= levelCost;
       xpSpent[msg.sender] += levelCost;
@@ -40,7 +40,7 @@ contract Forge is IForge, Ownable {
 
   function adjustXp(address _account, uint32 _xp) external onlyOwner {
     xp[_account] = _xp;
-    if(xpSpent[_account] > _xp) {
+    if (xpSpent[_account] > _xp) {
       xpSpent[_account] = _xp;
     }
   }

--- a/contracts/contracts/Forge.sol
+++ b/contracts/contracts/Forge.sol
@@ -21,7 +21,7 @@ contract Forge is IForge, Ownable {
   error LevelUpOutOfBounds(uint8 toLevel, uint8 maxLevel);
   error LevelUpInsufficientXP(uint8 atLevel, uint32 xpAvailable, uint32 xpCost);
 
-  mapping(address => Points) public points;
+  mapping(address => Points) internal points;
 
   mapping(uint256 => uint8) public override level; // wand tokenId -> level
   uint32[] public override levelUpCost; // array of xp cost for upgrading to the respective levels

--- a/contracts/contracts/Forge.sol
+++ b/contracts/contracts/Forge.sol
@@ -40,10 +40,12 @@ contract Forge is IForge, Ownable {
 
   mapping(uint256 => uint8) public override level; // wand tokenId -> level
   uint32[] public override levelUpCost; // array of xp cost for upgrading to the respective levels
+  uint32 public override xpLeader;
 
   constructor(IOwnerOf _wand, uint32[] memory levels) {
     wand = _wand;
     levelUpCost = levels;
+    xpLeader = 1;
   }
 
   function xp(address account) external view override returns (uint32) {
@@ -96,6 +98,10 @@ contract Forge is IForge, Ownable {
   }
 
   function adjustXp(address account, uint32 accrued) external onlyOwner {
+    if (accrued > xpLeader) {
+      xpLeader = accrued;
+    }
+
     uint32 spent = score[account].spent > accrued
       ? accrued
       : score[account].spent;
@@ -107,5 +113,9 @@ contract Forge is IForge, Ownable {
 
   function setLevelUpCost(uint32[] memory levels) external onlyOwner {
     levelUpCost = levels;
+  }
+
+  function setXpLeader(uint32 _xpLeader) external onlyOwner {
+    xpLeader = _xpLeader;
   }
 }

--- a/contracts/contracts/Forge.sol
+++ b/contracts/contracts/Forge.sol
@@ -11,7 +11,7 @@ interface IOwnerOf {
 contract Forge is IForge, Ownable {
   IOwnerOf public immutable wand;
 
-  struct Experience {
+  struct Points {
     uint32 accrued;
     uint32 spent;
   }
@@ -21,7 +21,7 @@ contract Forge is IForge, Ownable {
   error LevelUpOutOfBounds(uint8 toLevel, uint8 maxLevel);
   error LevelUpInsufficientXP(uint8 atLevel, uint32 xpAvailable, uint32 xpCost);
 
-  mapping(address => Experience) public experience;
+  mapping(address => Points) public points;
 
   mapping(uint256 => uint8) public override level; // wand tokenId -> level
   uint32[] public override levelUpCost; // array of xp cost for upgrading to the respective levels
@@ -32,11 +32,11 @@ contract Forge is IForge, Ownable {
   }
 
   function xp(address account) external view override returns (uint32) {
-    return experience[account].accrued;
+    return points[account].accrued;
   }
 
   function xpSpent(address account) external view override returns (uint32) {
-    return experience[account].spent;
+    return points[account].spent;
   }
 
   function levelUp(uint256 tokenId, uint8 toLevel) external override {
@@ -54,8 +54,8 @@ contract Forge is IForge, Ownable {
       revert LevelUpOutOfBounds({toLevel: toLevel, maxLevel: maxLevel});
     }
 
-    uint32 spent = experience[msg.sender].spent;
-    uint32 available = experience[msg.sender].accrued - spent;
+    uint32 spent = points[msg.sender].spent;
+    uint32 available = points[msg.sender].accrued - spent;
 
     for (uint8 atLevel = currLevel; atLevel < toLevel; atLevel++) {
       uint32 cost = levelUpCost[atLevel];
@@ -73,13 +73,13 @@ contract Forge is IForge, Ownable {
     }
 
     level[tokenId] = toLevel;
-    experience[msg.sender].spent = spent;
+    points[msg.sender].spent = spent;
   }
 
   function adjustXp(address account, uint32 accrued) external onlyOwner {
-    uint32 spent = experience[account].spent;
+    uint32 spent = points[account].spent;
 
-    experience[account] = Experience({
+    points[account] = Points({
       accrued: accrued,
       spent: spent > accrued ? accrued : spent
     });

--- a/contracts/contracts/Forge.sol
+++ b/contracts/contracts/Forge.sol
@@ -28,8 +28,8 @@ contract Forge is IForge, Ownable {
     require(_toLevel <= nextLevelXp.length, "Level out of bounds");
 
     uint32 availableXp = xp[msg.sender] - xpSpent[msg.sender];
-    for (uint8 i = level[_tokenId] + 1; i <= _toLevel; i++) {
-      uint32 levelCost = nextLevelXp[i - 1]; // -1 because level 0 is the default and not listed in the nextLevelXp cost array
+    for (uint8 i = level[_tokenId]; i < _toLevel; i++) {
+      uint32 levelCost = nextLevelXp[i];
       require(availableXp >= levelCost, "Not enough XP to spend");
       availableXp -= levelCost;
       xpSpent[msg.sender] += levelCost;

--- a/contracts/contracts/Forge.sol
+++ b/contracts/contracts/Forge.sol
@@ -22,10 +22,14 @@ contract Forge is IForge, Ownable {
     levels = _levels;
   }
 
+  function nextLevelXp(uint8 _currentLevel) override external view returns (uint32) {
+    return levels[_currentLevel]; // level 0 is not listed in the levels cost array, so we find the cost for the next level under the index of the current level
+  }
+
   function levelUp(uint256 _tokenId, uint8 _level) override external {
     require(wand.ownerOf(_tokenId) == msg.sender, "Not your wand");
     require(_level > level[_tokenId], "Already at or above that level");
-    require(_level <= levels.length, "Invalid level");
+    require(_level <= levels.length, "Level out of bounds");
 
     uint32 availableXp = xp[msg.sender] - xpSpent[msg.sender];
     for(uint8 i = level[_tokenId] + 1; i <= _level; i++) {

--- a/contracts/contracts/Forge.sol
+++ b/contracts/contracts/Forge.sol
@@ -9,7 +9,7 @@ interface ITrackOwnership {
 }
 
 contract Forge is IForge, Ownable {
-  uint32[] public levels; // array of xp cost for upgrading to the respective levels
+  uint32[] override public nextLevelXp; // array of xp cost for upgrading to the respective levels
 
   mapping(uint256 => uint8) override public level; // wand tokenId -> level
   mapping(address => uint32) override public xp; // account -> total gained XP
@@ -19,27 +19,23 @@ contract Forge is IForge, Ownable {
 
   constructor(ITrackOwnership _wand, uint32[] memory _levels) {
     wand = _wand;
-    levels = _levels;
+    nextLevelXp = _levels;
   }
 
-  function nextLevelXp(uint8 _currentLevel) override external view returns (uint32) {
-    return levels[_currentLevel]; // level 0 is not listed in the levels cost array, so we find the cost for the next level under the index of the current level
-  }
-
-  function levelUp(uint256 _tokenId, uint8 _level) override external {
+  function levelUp(uint256 _tokenId, uint8 _toLevel) override external {
     require(wand.ownerOf(_tokenId) == msg.sender, "Not your wand");
-    require(_level > level[_tokenId], "Already at or above that level");
-    require(_level <= levels.length, "Level out of bounds");
+    require(_toLevel > level[_tokenId], "Already at or above that level");
+    require(_toLevel <= nextLevelXp.length, "Level out of bounds");
 
     uint32 availableXp = xp[msg.sender] - xpSpent[msg.sender];
-    for(uint8 i = level[_tokenId] + 1; i <= _level; i++) {
-      uint32 levelCost = levels[i-1]; // -1 because level 0 is the default and not listed in the levels cost array
+    for(uint8 i = level[_tokenId] + 1; i <= _toLevel; i++) {
+      uint32 levelCost = nextLevelXp[i-1]; // -1 because level 0 is the default and not listed in the nextLevelXp cost array
       require(availableXp >= levelCost, "Not enough XP to spend");
       availableXp -= levelCost;
       xpSpent[msg.sender] += levelCost;
     }
 
-    level[_tokenId] = _level;
+    level[_tokenId] = _toLevel;
   }
 
   function adjustXp(address _account, uint32 _xp) external onlyOwner {
@@ -49,21 +45,7 @@ contract Forge is IForge, Ownable {
     }
   }
 
-  function adjustXpBatch(address[] memory _accounts, uint32[] memory _xps)
-    external
-    onlyOwner
-  {
-    require(_accounts.length == _xps.length);
-
-    for (uint256 i = 0; i < _accounts.length; i++) {
-      xp[_accounts[i]] = _xps[i];
-      if(xpSpent[_accounts[i]] > _xps[i]) {
-        xpSpent[_accounts[i]] = _xps[i];
-      }
-    }
-  }
-
   function setLevels(uint32[] memory _levels) external onlyOwner {
-    levels = _levels;
+    nextLevelXp = _levels;
   }
 }

--- a/contracts/contracts/ZodiacWands.sol
+++ b/contracts/contracts/ZodiacWands.sol
@@ -120,11 +120,13 @@ contract ZodiacWands is ERC721, GatedMint, Ownable {
   function unpack(uint256 tokenId) internal view returns (Wand memory) {
     Wand memory wand = Decanter.unpack(tokenId, wands[tokenId]);
 
-    address owner = ownerOf(tokenId);
     wand.level = forge.level(tokenId);
-    wand.xp.amount = forge.xp(owner) - forge.xpSpent(owner);
-    wand.xp.cap = forge.nextLevelXp(wand.level);
-    wand.xp.crown = wand.xp.amount >= wand.xp.cap;
+
+    address owner = ownerOf(tokenId);
+    uint32 amount = forge.xp(owner) - forge.xpSpent(owner);
+    uint32 cap = forge.levelUpCost(wand.level);
+
+    wand.xp = Cauldron.Xp({amount: amount, cap: cap, crown: amount >= cap});
 
     return wand;
   }

--- a/contracts/contracts/ZodiacWands.sol
+++ b/contracts/contracts/ZodiacWands.sol
@@ -119,10 +119,12 @@ contract ZodiacWands is ERC721, GatedMint, Ownable {
 
   function unpack(uint256 tokenId) internal view returns (Wand memory) {
     Wand memory wand = Decanter.unpack(tokenId, wands[tokenId]);
-    wand.xp = address(forge) != address(0)
-      ? forge.xp(ERC721.ownerOf(tokenId))
-      : 0;
-    wand.level = address(forge) != address(0) ? forge.level(tokenId) : 0;
+
+    address owner = ownerOf(tokenId);
+    wand.level = forge.level(tokenId);
+    wand.xp.amount = forge.xp(owner) - forge.xpSpent(owner);
+    wand.xp.cap = forge.nextLevelXp(wand.level);
+    wand.xp.crown = wand.xp.amount >= wand.xp.cap;
 
     return wand;
   }

--- a/contracts/contracts/ZodiacWands.sol
+++ b/contracts/contracts/ZodiacWands.sol
@@ -122,9 +122,8 @@ contract ZodiacWands is ERC721, GatedMint, Ownable {
 
     wand.level = forge.level(tokenId);
 
-    address owner = ownerOf(tokenId);
-    uint32 amount = forge.xp(owner) - forge.xpSpent(owner);
-    uint32 cap = forge.levelUpCost(wand.level);
+    uint32 amount = forge.xp(ownerOf(tokenId));
+    uint32 cap = forge.xpLeader();
 
     wand.xp = Cauldron.Xp({amount: amount, cap: cap, crown: amount >= cap});
 

--- a/contracts/contracts/interfaces/IForge.sol
+++ b/contracts/contracts/interfaces/IForge.sol
@@ -4,11 +4,11 @@ pragma solidity ^0.8.6;
 interface IForge {
   function level(uint256 tokenId) external view returns (uint8);
 
-  function xp(address avatar) external view returns (uint32);
+  function xp(address account) external view returns (uint32);
 
-  function xpSpent(address avatar) external view returns (uint32);
+  function xpSpent(address account) external view returns (uint32);
 
-  function nextLevelXp(uint256 _currentLevel) external view returns (uint32);
+  function levelUpCost(uint256 currentLevel) external view returns (uint32);
 
-  function levelUp(uint256 _tokenId, uint8 _level) external;
+  function levelUp(uint256 tokenId, uint8 level) external;
 }

--- a/contracts/contracts/interfaces/IForge.sol
+++ b/contracts/contracts/interfaces/IForge.sol
@@ -8,6 +8,8 @@ interface IForge {
 
   function xpSpent(address account) external view returns (uint32);
 
+  function xpLeader() external view returns (uint32);
+
   function levelUpCost(uint256 currentLevel) external view returns (uint32);
 
   function levelUp(uint256 tokenId, uint8 level) external;

--- a/contracts/contracts/interfaces/IForge.sol
+++ b/contracts/contracts/interfaces/IForge.sol
@@ -5,7 +5,7 @@ interface IForge {
   function level(uint256 tokenId) external view returns (uint8);
   function xp(address avatar) external view returns (uint32);
   function xpSpent(address avatar) external view returns (uint32);
-  function nextLevelXp(uint8 _currentLevel) external view returns (uint32);
+  function nextLevelXp(uint256 _currentLevel) external view returns (uint32);
   
   function levelUp(uint256 _tokenId, uint8 _level) external;
 }

--- a/contracts/contracts/interfaces/IForge.sol
+++ b/contracts/contracts/interfaces/IForge.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.8.6;
 
 interface IForge {
   function level(uint256 tokenId) external view returns (uint8);
+
   function xp(address avatar) external view returns (uint32);
+
   function xpSpent(address avatar) external view returns (uint32);
+
   function nextLevelXp(uint256 _currentLevel) external view returns (uint32);
-  
+
   function levelUp(uint256 _tokenId, uint8 _level) external;
 }

--- a/contracts/contracts/interfaces/IForge.sol
+++ b/contracts/contracts/interfaces/IForge.sol
@@ -2,12 +2,10 @@
 pragma solidity ^0.8.6;
 
 interface IForge {
-  struct Character {
-    uint256 XP;
-    uint256 XPAssigned;
-  }
-
-  function level(uint256 tokenId) external view returns (uint32);
-
+  function level(uint256 tokenId) external view returns (uint8);
   function xp(address avatar) external view returns (uint32);
+  function xpSpent(address avatar) external view returns (uint32);
+  function nextLevelXp(uint8 _currentLevel) external view returns (uint32);
+  
+  function levelUp(uint256 _tokenId, uint8 _level) external;
 }

--- a/contracts/contracts/interfaces/Types.sol
+++ b/contracts/contracts/interfaces/Types.sol
@@ -25,8 +25,8 @@ struct Wand {
   Cauldron.Background background;
   Planet[8] planets;
   Aspect[8] aspects;
-  uint32 xp;
-  uint32 level;
+  uint8 level;
+  Cauldron.Xp xp;
 }
 
 struct PackedWand {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -6,6 +6,7 @@
     "test": "test"
   },
   "scripts": {
+    "clean": "rimraf build typechain-types",
     "compile:cauldron": "solid-mustache ../svg/template.svg.hbs -o ./contracts/Cauldron.sol --name Cauldron --condense --dedupeThreshold=128",
     "compile": "hardhat compile",
     "test": "hardhat test",
@@ -49,6 +50,7 @@
     "hardhat-gas-reporter": "^1.0.9",
     "prettier": "2.7.1",
     "prettier-plugin-solidity": "1.0.0-dev.23",
+    "rimraf": "^3.0.2",
     "solhint": "3.3.7",
     "solhint-plugin-prettier": "0.0.5",
     "solidity-coverage": "^0.8.2",

--- a/contracts/src/deploy/01_deploy_wand.ts
+++ b/contracts/src/deploy/01_deploy_wand.ts
@@ -35,7 +35,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   });
 
   // These are NOT XP thresholds, but the XP amounts to spend to level up to the respective level from the previous one
-  const levels = [128, 256, 512, 1024];
+  const levels = [2000, 2000, 2000, 2000];
   const txForge = await deploy("Forge", {
     from: deployer,
     args: [txZodiacWands.address, levels],

--- a/contracts/src/deploy/01_deploy_wand.ts
+++ b/contracts/src/deploy/01_deploy_wand.ts
@@ -38,7 +38,7 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const levels = [128, 256, 512, 1024];
   const txForge = await deploy("Forge", {
     from: deployer,
-    args: [txZodiacWands.address],
+    args: [txZodiacWands.address, levels],
     log: true,
   });
 

--- a/contracts/src/deploy/01_deploy_wand.ts
+++ b/contracts/src/deploy/01_deploy_wand.ts
@@ -33,6 +33,9 @@ const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     args: [txConjuror.address, rootHash],
     log: true,
   });
+
+  // These are NOT XP thresholds, but the XP amounts to spend to level up to the respective level from the previous one
+  const levels = [128, 256, 512, 1024];
   const txForge = await deploy("Forge", {
     from: deployer,
     args: [txZodiacWands.address],

--- a/contracts/test/Conjuror.spec.ts
+++ b/contracts/test/Conjuror.spec.ts
@@ -54,12 +54,6 @@ describe("Conjuror", async () => {
         expect(fromJS.rotation).to.equal(fromSolidity.rotation);
       };
 
-      // cycling through all takes time
-      // for (let stoneId = 0; stoneId < 3600; stoneId++) {
-      //   console.log(stoneId);
-      //   await checkIt(stoneId);
-      // }
-
       //random values
       await checkIt(3210);
       await checkIt(3014);
@@ -83,20 +77,10 @@ describe("Conjuror", async () => {
           progress: solProgress,
         } = await wandConjurorExposer._interpolationParams(stoneId);
         const [jsFrom, jsTo, jsProgress] = interpolationParams(stoneId);
-        // console.log(stoneId);
-        // console.log(solFrom, solTo);
-        // console.log(jsFrom, jsTo);
-        // console.log(jsProgress, solProgress);
         expect(solFrom).to.equal(jsFrom);
         expect(solTo).to.equal(jsTo);
         expect(solProgress).to.equal(jsProgress);
       };
-
-      // // cycling through all takes time
-      // for (let stoneId = 0; stoneId < 3600; stoneId++) {
-      //   console.log(stoneId);
-      //   await checkIt(stoneId);
-      // }
 
       // random values
       await checkIt(1251);

--- a/contracts/test/Forge.spec.ts
+++ b/contracts/test/Forge.spec.ts
@@ -135,9 +135,13 @@ describe("Forge", async () => {
 
       await forge.adjustXp(wandHolder.address, 10000000);
 
-      await expect(forge.connect(wandHolder).levelUp(wandTokenId, 5))
+      const fromLevel = 0;
+      const toLevel = 5;
+      const maxLevel = 4;
+
+      await expect(forge.connect(wandHolder).levelUp(wandTokenId, toLevel))
         .to.be.revertedWithCustomError(forge, "LevelUpOutOfBounds")
-        .withArgs(5, 4);
+        .withArgs(fromLevel, toLevel, maxLevel);
     });
 
     it("reverts if the account does not have enough unspent XP", async function () {
@@ -152,9 +156,13 @@ describe("Forge", async () => {
 
       const xpAvailable = costToLevelUpFrom1 - 1;
 
-      await expect(forge.connect(wandHolder).levelUp(wandTokenId, 2))
+      const fromLevel = 0;
+      const toLevel = 2;
+      const atLevel = 1;
+
+      await expect(forge.connect(wandHolder).levelUp(wandTokenId, toLevel))
         .to.be.revertedWithCustomError(forge, "LevelUpInsufficientXP")
-        .withArgs(1, xpAvailable, costToLevelUpFrom1);
+        .withArgs(fromLevel, toLevel, atLevel, xpAvailable, costToLevelUpFrom1);
     });
 
     it("updates the spent XP", async function () {

--- a/contracts/test/Forge.spec.ts
+++ b/contracts/test/Forge.spec.ts
@@ -263,6 +263,7 @@ const mintWand = async (
     // doesnt matter
     stage: MintStage.IDLE,
     tokenId: -1,
+    showJourney: false,
   };
   const date = new Date("2022-10-01");
 

--- a/contracts/test/Forge.spec.ts
+++ b/contracts/test/Forge.spec.ts
@@ -1,0 +1,243 @@
+import { expect } from "chai";
+import hre, { deployments, ethers } from "hardhat";
+import "@nomiclabs/hardhat-ethers";
+import { Contract, Signer } from "ethers";
+import { Forge__factory, ZodiacWands } from "../typechain-types";
+import MerkleTree from "merkletreejs";
+import { AppState, MintStage } from "../../apps/minting-app/types";
+import { packForMinting } from "../../apps/minting-app/state/transforms";
+
+describe("Forge", async () => {
+  const baseSetup = deployments.createFixture(async () => {
+    await deployments.fixture();
+
+    const signers = await hre.ethers.getSigners();
+    const [contractOwner, wandHolder, otherWandHolder] = signers;
+
+    const deployment = await deployments.get("ZodiacWands");
+    const zodiacWands = new Contract(
+      deployment.address,
+      deployment.abi,
+      contractOwner
+    ) as ZodiacWands;
+
+    const elements = await Promise.all(signers.map((s) => s.getAddress()));
+    const merkleTree = new MerkleTree(elements, keccak256, {
+      hashLeaves: true,
+      sortPairs: true,
+    });
+
+    const getPermit = (minter: string) => {
+      const proof = merkleTree.getHexProof(keccak256(minter));
+      return { proof, signature: "0x" };
+    };
+
+    const forgeAddress = await zodiacWands.forge();
+    const forge = Forge__factory.connect(forgeAddress, contractOwner);
+
+    const wandTokenId = await mintWand(
+      zodiacWands,
+      wandHolder,
+      getPermit(wandHolder.address)
+    );
+    const otherWandTokenId = await mintWand(
+      zodiacWands,
+      otherWandHolder,
+      getPermit(otherWandHolder.address)
+    );
+
+    return {
+      zodiacWands,
+      forge,
+      contractOwner,
+      wandTokenId,
+      wandHolder,
+      otherWandTokenId,
+      otherWandHolder,
+    };
+  });
+
+  const keccak256 = (input: string) => {
+    const toBytes =
+      typeof input === "string" && !ethers.utils.isHexString(input);
+
+    return ethers.utils.keccak256(
+      toBytes ? ethers.utils.toUtf8Bytes(input) : input
+    );
+  };
+
+  describe("adjustXp", function () {
+    it("reverts if not called by contract owner", async function () {});
+
+    it("updates the XP of the account", async function () {
+      const { forge, wandHolder } = await baseSetup();
+
+      const xp = 100;
+      await forge.adjustXp(wandHolder.address, xp);
+      expect(await forge.xp(wandHolder.address)).to.equal(xp);
+      expect(await forge.xpSpent(wandHolder.address)).to.equal(0);
+    });
+
+    it("adjusts spent XP if the new XP amount is lower", async function () {
+      const { forge, wandHolder, wandTokenId } = await baseSetup();
+
+      const xp = 150;
+      await forge.adjustXp(wandHolder.address, xp);
+      await forge.connect(wandHolder).levelUp(wandTokenId, 1);
+      expect(await forge.xpSpent(wandHolder.address)).to.equal(128);
+
+      await forge.adjustXp(wandHolder.address, 100);
+      expect(await forge.xpSpent(wandHolder.address)).to.equal(100);
+    });
+
+    it.skip('emits "XpAdjusted" event', async function () {
+      const { forge, wandHolder } = await baseSetup();
+
+      const xp = 100;
+      const tx = await forge.adjustXp(wandHolder.address, xp);
+      const receipt = await tx.wait();
+
+      const event = receipt.events?.find((e) => e.event === "XpAdjusted");
+      expect(event?.args?.xp).to.equal(xp);
+    });
+  });
+
+  describe("levelUp", function () {
+    it("reverts if the wand is not owned by the sender", async function () {
+      const { forge, wandTokenId, wandHolder } = await baseSetup();
+
+      await forge.adjustXp(wandHolder.address, 128);
+
+      await expect(forge.levelUp(wandTokenId, 1)).to.be.revertedWith(
+        "Not your wand"
+      );
+    });
+
+    it("reverts if the wand is already at or above that level", async function () {
+      const { forge, wandTokenId, wandHolder } = await baseSetup();
+
+      await forge.adjustXp(wandHolder.address, 128);
+
+      await expect(
+        forge.connect(wandHolder).levelUp(wandTokenId, 0)
+      ).to.be.revertedWith("Already at or above that level");
+    });
+
+    it("reverts if the level is higher than the maximum level", async function () {
+      const { forge, wandTokenId, wandHolder } = await baseSetup();
+
+      await forge.adjustXp(wandHolder.address, 10000000);
+
+      await expect(
+        forge.connect(wandHolder).levelUp(wandTokenId, 5)
+      ).to.be.revertedWith("Level out of bounds");
+    });
+
+    it("reverts if the account does not have enough unspent XP", async function () {
+      const { forge, wandTokenId, wandHolder } = await baseSetup();
+
+      await forge.adjustXp(wandHolder.address, 256);
+      await forge.connect(wandHolder).levelUp(wandTokenId, 1);
+
+      await expect(
+        forge.connect(wandHolder).levelUp(wandTokenId, 2)
+      ).to.be.revertedWith("Not enough XP to spend");
+    });
+
+    it("updates the spent XP", async function () {
+      const { forge, wandTokenId, wandHolder } = await baseSetup();
+
+      await forge.adjustXp(wandHolder.address, 256);
+      await forge.connect(wandHolder).levelUp(wandTokenId, 1);
+
+      expect(await forge.level(wandTokenId)).to.equal(1);
+      expect(await forge.xpSpent(wandHolder.address)).to.equal(128);
+      expect(await forge.xp(wandHolder.address)).to.equal(256);
+    });
+
+    it("can upgrade over multiple levels", async function () {
+      const { forge, wandTokenId, wandHolder } = await baseSetup();
+
+      await forge.adjustXp(wandHolder.address, 500);
+      await forge.connect(wandHolder).levelUp(wandTokenId, 2);
+
+      expect(await forge.level(wandTokenId)).to.equal(2);
+      expect(await forge.xpSpent(wandHolder.address)).to.equal(128 + 256);
+      expect(await forge.xp(wandHolder.address)).to.equal(500);
+    });
+
+    it.skip('emits a "LeveledUp" event for each level', async function () {
+      const { forge, wandTokenId, wandHolder } = await baseSetup();
+
+      await forge.adjustXp(wandHolder.address, 500);
+      const tx = await forge.connect(wandHolder).levelUp(wandTokenId, 2);
+      const receipt = await tx.wait();
+
+      const events =
+        receipt.events?.filter((e) => e.event === "LeveledUp") || [];
+      expect(events).to.have.length(2);
+      expect(events[0].args?.level).to.equal(1);
+      expect(events[1].args?.level).to.equal(2);
+    });
+  });
+});
+
+let tokenId = 0;
+const mintWand = async (
+  zodiacWands: ZodiacWands,
+  minter: Signer,
+  permit: {
+    proof: string[];
+    signature: string;
+  }
+) => {
+  const background = {
+    radial: true,
+    dark: true,
+    color: {
+      hue: 281,
+      saturation: 33,
+      lightness: 41,
+    },
+  };
+
+  const latBerlin = 52.5422;
+  const lngBerlin = 13.3495;
+
+  const state: AppState = {
+    stone: 1,
+    handle: 2,
+    background,
+    latitude: latBerlin,
+    longitude: lngBerlin,
+    halo: {
+      shape: 1,
+      rhythm: [
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        true,
+        false,
+        false,
+      ],
+    },
+    // doesnt matter
+    stage: MintStage.IDLE,
+    tokenId: -1,
+  };
+  const date = new Date("2022-10-01");
+
+  const tx = await zodiacWands
+    .connect(minter)
+    .mint(...packForMinting(state, date), permit);
+  await tx.wait();
+
+  return tokenId++;
+};

--- a/contracts/test/Forge.spec.ts
+++ b/contracts/test/Forge.spec.ts
@@ -116,7 +116,7 @@ describe("Forge", async () => {
 
       await expect(forge.levelUp(wandTokenId, 1)).to.be.revertedWithCustomError(
         forge,
-        "LevelUpUnauthorized"
+        "NotYourWand"
       );
     });
 
@@ -126,7 +126,7 @@ describe("Forge", async () => {
       await forge.adjustXp(wandHolder.address, 10000000);
 
       await expect(forge.connect(wandHolder).levelUp(wandTokenId, 0))
-        .to.be.revertedWithCustomError(forge, "LevelUpAlreadyThere")
+        .to.be.revertedWithCustomError(forge, "WithinCurrentLevel")
         .withArgs(0, 0);
     });
 
@@ -140,7 +140,7 @@ describe("Forge", async () => {
       const maxLevel = 4;
 
       await expect(forge.connect(wandHolder).levelUp(wandTokenId, toLevel))
-        .to.be.revertedWithCustomError(forge, "LevelUpOutOfBounds")
+        .to.be.revertedWithCustomError(forge, "BeyondMaxLevel")
         .withArgs(fromLevel, toLevel, maxLevel);
     });
 
@@ -161,7 +161,7 @@ describe("Forge", async () => {
       const atLevel = 1;
 
       await expect(forge.connect(wandHolder).levelUp(wandTokenId, toLevel))
-        .to.be.revertedWithCustomError(forge, "LevelUpInsufficientXP")
+        .to.be.revertedWithCustomError(forge, "InsufficientXP")
         .withArgs(fromLevel, toLevel, atLevel, xpAvailable, costToLevelUpFrom1);
     });
 

--- a/contracts/test/ZodiacWands.spec.ts
+++ b/contracts/test/ZodiacWands.spec.ts
@@ -177,6 +177,7 @@ describe("ZodiacWands", async () => {
         // doesnt matter
         stage: MintStage.IDLE,
         tokenId: -1,
+        showJourney: false,
       };
       const date = new Date("2022-10-01");
 

--- a/contracts/test/ZodiacWands.spec.ts
+++ b/contracts/test/ZodiacWands.spec.ts
@@ -46,7 +46,6 @@ describe("ZodiacWands", async () => {
       const { zodiacWands, permit } = await baseSetup();
 
       const background = {
-        hue: 0,
         radial: true,
         dark: true,
         color: {
@@ -88,8 +87,9 @@ describe("ZodiacWands", async () => {
         tokenId: -1,
         showJourney: false,
       };
+      const date = new Date("2022-10-01");
 
-      const tx = await zodiacWands.mint(...packForMinting(state), permit);
+      const tx = await zodiacWands.mint(...packForMinting(state, date), permit);
 
       await tx.wait();
 
@@ -111,7 +111,7 @@ describe("ZodiacWands", async () => {
       const seed = parseInt(keccak256(signer.address).slice(-4), 16);
 
       const svgFromJS = renderSvgTemplate({
-        ...transformForRendering(state, seed),
+        ...transformForRendering(state, seed, date),
         // sparkles and name are not on the preview, we mimick solidity
         sparkles: generateSparkles(tokenId),
         frame: {

--- a/contracts/test/ZodiacWands.spec.ts
+++ b/contracts/test/ZodiacWands.spec.ts
@@ -121,7 +121,7 @@ describe("ZodiacWands", async () => {
           level1: true,
           title: generateName(tokenId),
         },
-        xp: { amount: 0, cap: 128, crown: false },
+        xp: { amount: 0, cap: 2000, crown: false },
       });
 
       expect(svgFromSol).to.equal(svgFromJS);
@@ -177,6 +177,9 @@ describe("ZodiacWands", async () => {
       };
       const date = new Date("2022-10-01");
 
+      const xpAccrued = 6000;
+      const levelUpCost = 2000;
+
       const tx = await zodiacWands
         .connect(minter)
         .mint(...packForMinting(state, date), getPermit(minter.address));
@@ -186,7 +189,7 @@ describe("ZodiacWands", async () => {
       const wandOwner = await zodiacWands.ownerOf(tokenId);
       expect(wandOwner).to.equal(minter.address);
 
-      await forge.adjustXp(wandOwner, 150); // give XP to wand owner
+      await forge.adjustXp(wandOwner, xpAccrued); // give XP to wand owner
       await forge.connect(minter).levelUp(tokenId, 1); // wand owner redeems XP for leveling up the wand
       expect(await forge.level(tokenId)).to.equal(1);
 
@@ -212,7 +215,7 @@ describe("ZodiacWands", async () => {
           level2: true,
           title: generateName(tokenId),
         },
-        xp: { amount: 150 - 128, cap: 256, crown: false },
+        xp: { amount: xpAccrued - levelUpCost, cap: levelUpCost, crown: true },
       });
 
       expect(svgFromSol).to.equal(svgFromJS);

--- a/contracts/test/ZodiacWands.spec.ts
+++ b/contracts/test/ZodiacWands.spec.ts
@@ -101,7 +101,6 @@ describe("ZodiacWands", async () => {
       );
       await tx.wait();
       const tokenId = 0;
-      const levelUpCost = await forge.levelUpCost(0);
 
       const tokenUri = await zodiacWands.tokenURI(tokenId);
       const tokenUriJson = JSON.parse(
@@ -125,7 +124,7 @@ describe("ZodiacWands", async () => {
           level1: true,
           title: generateName(tokenId),
         },
-        xp: { amount: 0, cap: levelUpCost, crown: false },
+        xp: { amount: 0, cap: 1, crown: false },
       });
 
       expect(svgFromSol).to.equal(svgFromJS);
@@ -137,11 +136,6 @@ describe("ZodiacWands", async () => {
 
       const forgeAddress = await zodiacWands.forge();
       const forge = Forge__factory.connect(forgeAddress, signer);
-
-      const levelUpCosts = [
-        await forge.levelUpCost(0),
-        await forge.levelUpCost(1),
-      ];
 
       const background = {
         radial: false,
@@ -215,8 +209,8 @@ describe("ZodiacWands", async () => {
 
       const seed = parseInt(keccak256(minter.address).slice(-4), 16);
 
-      const xpAmount = xpAccrued - levelUpCosts[0];
-      const xpCap = levelUpCosts[1];
+      const xpAmount = xpAccrued;
+      const xpCap = await forge.xpLeader();
       const xpCrown = xpAccrued >= xpCap;
 
       const svgFromJS = renderSvgTemplate({

--- a/contracts/test/ZodiacWands.spec.ts
+++ b/contracts/test/ZodiacWands.spec.ts
@@ -13,7 +13,7 @@ import { transformForRendering } from "../../apps/minting-app/state/transforms/f
 import { keccak256 } from "ethers/lib/utils";
 import { AppState, MintStage } from "../../apps/minting-app/types";
 import MerkleTree from "merkletreejs";
-import { ZodiacWands } from "../typechain-types";
+import { Forge__factory, ZodiacWands } from "../typechain-types";
 
 describe("ZodiacWands", async () => {
   const baseSetup = deployments.createFixture(async () => {
@@ -21,7 +21,6 @@ describe("ZodiacWands", async () => {
 
     const signers = await hre.ethers.getSigners();
     const [signer] = signers;
-    const signerAddress = await signer.getAddress();
 
     const deployment = await deployments.get("ZodiacWands");
     const zodiacWands = new Contract(
@@ -36,14 +35,18 @@ describe("ZodiacWands", async () => {
       sortPairs: true,
     });
 
-    const proof = merkleTree.getHexProof(keccak256(signerAddress));
+    const getPermit = (minter: string) => {
+      const proof = merkleTree.getHexProof(keccak256(minter));
+      return { proof, signature: "0x" };
+    };
 
-    return { zodiacWands, permit: { proof, signature: "0x" } };
+    return { zodiacWands, getPermit };
   });
 
   describe("SVG generation", () => {
-    it("it render the template with the same results as JavaScript", async () => {
-      const { zodiacWands, permit } = await baseSetup();
+    it("it render the template with the same results as JavaScript (fresh mint)", async () => {
+      const [signer] = await hre.ethers.getSigners();
+      const { zodiacWands, getPermit } = await baseSetup();
 
       const background = {
         radial: true,
@@ -89,11 +92,13 @@ describe("ZodiacWands", async () => {
       };
       const date = new Date("2022-10-01");
 
-      const tx = await zodiacWands.mint(...packForMinting(state, date), permit);
-
+      const tx = await zodiacWands.mint(
+        ...packForMinting(state, date),
+        getPermit(signer.address)
+      );
       await tx.wait();
-
       const tokenId = 0;
+
       const tokenUri = await zodiacWands.tokenURI(tokenId);
       const tokenUriJson = JSON.parse(
         atob(
@@ -106,8 +111,6 @@ describe("ZodiacWands", async () => {
         tokenUriJson.image.substring("data:image/svg+xml;base64,".length)
       );
 
-      const [signer] = await hre.ethers.getSigners();
-
       const seed = parseInt(keccak256(signer.address).slice(-4), 16);
 
       const svgFromJS = renderSvgTemplate({
@@ -118,6 +121,98 @@ describe("ZodiacWands", async () => {
           level1: true,
           title: generateName(tokenId),
         },
+        xp: { amount: 0, cap: 128, crown: false },
+      });
+
+      expect(svgFromSol).to.equal(svgFromJS);
+    });
+
+    it("it render the template with the same results as JavaScript (level 2)", async () => {
+      const [signer, minter] = await hre.ethers.getSigners();
+      const { zodiacWands, getPermit } = await baseSetup();
+
+      const forgeAddress = await zodiacWands.forge();
+      const forge = Forge__factory.connect(forgeAddress, signer);
+
+      const background = {
+        radial: false,
+        dark: false,
+        color: {
+          hue: 11,
+          saturation: 22,
+          lightness: 33,
+        },
+      };
+
+      const latBrooklyn = 40.6782;
+      const lngBrooklyn = -73.9442;
+
+      const state: AppState = {
+        stone: 222,
+        handle: 3,
+        background,
+        latitude: latBrooklyn,
+        longitude: lngBrooklyn,
+        halo: {
+          shape: 2,
+          rhythm: [
+            true,
+            true,
+            false,
+            false,
+            true,
+            true,
+            false,
+            false,
+            true,
+            true,
+            true,
+            true,
+            true,
+          ],
+        },
+        // doesnt matter
+        stage: MintStage.IDLE,
+        tokenId: -1,
+      };
+      const date = new Date("2022-10-01");
+
+      const tx = await zodiacWands
+        .connect(minter)
+        .mint(...packForMinting(state, date), getPermit(minter.address));
+      await tx.wait();
+      const tokenId = 0;
+
+      const wandOwner = await zodiacWands.ownerOf(tokenId);
+      expect(wandOwner).to.equal(minter.address);
+
+      await forge.adjustXp(wandOwner, 150); // give XP to wand owner
+      await forge.connect(minter).levelUp(tokenId, 1); // wand owner redeems XP for leveling up the wand
+      expect(await forge.level(tokenId)).to.equal(1);
+
+      const tokenUri = await zodiacWands.tokenURI(tokenId);
+      const tokenUriJson = JSON.parse(
+        atob(
+          // remove the prefix
+          tokenUri.substring("data:application/json;base64,".length)
+        )
+      );
+      const svgFromSol = atob(
+        // remove the prefix
+        tokenUriJson.image.substring("data:image/svg+xml;base64,".length)
+      );
+
+      const seed = parseInt(keccak256(minter.address).slice(-4), 16);
+
+      const svgFromJS = renderSvgTemplate({
+        ...transformForRendering(state, seed, date),
+        // sparkles and name are not on the preview, we mimick solidity
+        sparkles: generateSparkles(tokenId),
+        frame: {
+          level2: true,
+          title: generateName(tokenId),
+        },
+        xp: { amount: 150 - 128, cap: 256, crown: false },
       });
 
       expect(svgFromSol).to.equal(svgFromJS);


### PR DESCRIPTION
**Changes in this PR**
- Make the Forge contract implement the intended XP/leveling system.
- Correctly visualize current level and XP in wand SVG
- Add tests

The implementation should now meet the specs, so closes #34 

**Implementation details:**
- each level is defined as XP cost for leveling up from previous level
- current levels, open for discussion: `128`, `256`, `512`, `1024` (idea: reaching the next level gets harder exponentially, cost doubles each level)
- when maximum level is reached, the XP indicator stays empty
- levels and XP assigned to accounts can be updated by the contract owner

closes #99 