### PR TITLE
Enable Optimizer

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -49,13 +49,21 @@ export default {
     sources: "contracts",
   },
   solidity: {
-    compilers: [{ version: "0.8.6" }, { version: "0.6.12" }],
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 1,
+    compilers: [
+      {
+        version: "0.8.6",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+            details: {
+              yul: false,
+            },
+          },
+        },
       },
-    },
+      { version: "0.6.12" },
+    ],
   },
   networks: {
     hardhat: {


### PR DESCRIPTION
The way we had our config setup was not enabling the modifier, with it enabled, deployments are smaller:
before:
<img width="731" alt="Screen Shot 2023-02-28 at 8 53 36 PM" src="https://user-images.githubusercontent.com/6718506/222033298-a6f62817-7564-45c7-bdfe-1e9cda2e4412.png">

after:
<img width="729" alt="Screen Shot 2023-02-28 at 8 53 25 PM" src="https://user-images.githubusercontent.com/6718506/222033314-c736f089-4580-4c6b-925a-dfbe15e26d48.png">

setting `yul: false` because it fails otherwise, [based on this thread](https://github.com/ethereum/solidity/issues/11638)
